### PR TITLE
Improve L2 acceptance test

### DIFF
--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -24,20 +24,20 @@ resource "packet_device" "test" {
   facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
-  project_id       = "${packet_project.test.id}"
+  project_id       = packet_project.test.id
   network_type     = "layer2-bonded"
 }
 
 resource "packet_vlan" "test1" {
   description = "test VLAN 1"
-  facility    = "nrt1"
-  project_id  = "${packet_project.test.id}"
+  facility    = packet_device.test.facility
+  project_id  = packet_project.test.id
 }
 
 resource "packet_vlan" "test2" {
   description = "test VLAN 2"
-  facility    = "nrt1"
-  project_id  = "${packet_project.test.id}"
+  facility    = packet_device.test.facility
+  project_id  = packet_project.test.id
 }
 
 resource "packet_port_vlan_attachment" "test1" {


### PR DESCRIPTION
VLAN-port attachment tests are failing in Hashicorp CI, mostly because of full capacity.

This PR will take advantace of the dynamic "facilitties" field in packet_device so that the L2 test device has better chance to be deployed.