### PR TITLE
add GH workflow for acceptance testing

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -1,0 +1,76 @@
+name: Acceptance Tests
+on:
+  pull_request:
+    paths-ignore:
+      - 'LICENSE'
+      - '**.md'
+      - 'website/**'
+      - 'docs/**'
+  push:
+    paths-ignore:
+      - 'LICENSE'
+      - '**.md'
+      - 'website/**'
+      - 'docs/**'
+  schedule:
+    - cron: '0 13 * * *'
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v2.1.2
+      with:
+        go-version: '1.15'
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2.3.2
+
+    - name: Get dependencies
+      run: |
+        go mod download
+    - name: Build
+      run: |
+        go build -v .
+  test:
+    name: Matrix Test
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - stable
+        terraform:
+          - '0.12.29'
+          - '0.13.3'
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v2.1.2
+      with:
+        go-version: '1.15'
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2.3.2
+
+    - name: Get dependencies
+      run: |
+        go mod download
+
+    - name: TF acceptance tests
+      timeout-minutes: 120
+      env:
+        TF_ACC: "1"
+        TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
+
+        PACKET_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
+      run: |
+        go test -v -cover ./packet

--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2.1.2
       with:
-        go-version: '1.15'
+        go-version: '1.13'
       id: go
 
     - name: Check out code into the Go module directory
@@ -55,7 +55,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2.1.2
       with:
-        go-version: '1.15'
+        go-version: '1.13'
       id: go
 
     - name: Check out code into the Go module directory
@@ -73,4 +73,4 @@ jobs:
 
         PACKET_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
       run: |
-        go test -v -cover ./packet
+        go test -v -cover -run=TestAccPacketProject_Basic ./packet

--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -76,7 +76,7 @@ jobs:
 
         PACKET_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
       run: |
-        go test -v -cover ./packet
+        go test -v -cover -parallel 4 -timeout 120m ./packet
     - name: Sweeper
       if: ${{ always() }}
       env:

--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -77,3 +77,9 @@ jobs:
         PACKET_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
       run: |
         go test -v -cover ./packet
+    - name: Sweeper
+      if: ${{ always() }}
+      env:
+        PACKET_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
+      run: |
+        go test ./packet -v -sweep="tf_test"

--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -70,7 +70,7 @@ jobs:
       env:
         TF_ACC: "1"
         TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
-        TF_SCHEMA_PANIC_ON_ERROR: "1"
+        # TF_SCHEMA_PANIC_ON_ERROR: "1"
         # TF_LOG: "DEBUG"
         #
 

--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -70,7 +70,10 @@ jobs:
       env:
         TF_ACC: "1"
         TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
+        TF_SCHEMA_PANIC_ON_ERROR: "1"
+        # TF_LOG: "DEBUG"
+        #
 
         PACKET_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
       run: |
-        go test -v -cover -run=TestAccPacketProject_Basic ./packet
+        go test -v -cover ./packet

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ website/node_modules
 *~
 .*.swp
 .idea
+.vscode
 *.iml
 *.test
 *.iml


### PR DESCRIPTION
This adds acceptance testing back into the PR workflow using Github Actions.
* [x] Requires a `PACKET_AUTH_TOKEN` to be added to https://github.com/packethost/terraform-provider-packet/settings/secrets

Previously, this was performed on Hashicorp managed servers in TeamCity.

I would like to restrict the PR builds to ones that have received a label of preliminary acceptance (something like "ok-to-test"), but I'd be ok with full acceptance testing being introduced before then (if we disable build-on-PR and only use build-on-push to the default branch).

I'm not sure if we want to add these environment variables to the build at this time, we can always add them later:

```
TF_SCHEMA_PANIC_ON_ERROR: "1" # I think this will be the default in TF sdk2
TF_LOG: "DEBUG"
```