### PR TITLE
tests: don't attempt acctest on pull requests

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -1,11 +1,5 @@
 name: Acceptance Tests
 on:
-  pull_request:
-    paths-ignore:
-      - 'LICENSE'
-      - '**.md'
-      - 'website/**'
-      - 'docs/**'
   push:
     paths-ignore:
       - 'LICENSE'


### PR DESCRIPTION
Pull requests which are based on `origin/` branches will be `acctest`'ed
because of the [`push` rule](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#push). The [`pull_request` rule](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request) can not work because
GH actions does not pass secrets to pull requests from forks.

Signed-off-by: Marques Johansson <marques@packet.com>