### PR TITLE
rename Packet to Equinix Metal

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at support@packet.com. All
+reported by contacting the project team at support@equinixmetal.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,7 +1,7 @@
 # Owners
 
-This project is governed by [Packet](https://packet.com) and benefits from a community of users that collaborate and contribute to its use in Kubernetes on Packet.
+This project is governed by [Equinix Metal](https://metal.equinix.com) and benefits from a community of users that collaborate and contribute to its use in Kubernetes on Equinix Metal.
 
-Members of the Packet Github organization will strive to triage issues in a timely manner, see [SUPPORT.md](.github/SUPPORT.md) for details.
+Members of the Equinix Metal Github organization will strive to triage issues in a timely manner, see [SUPPORT.md](.github/SUPPORT.md) for details.
 
 See the [packethost/standards glossary](https://github.com/packethost/standards/blob/master/glossary.md#ownersmd) for more details about this file.

--- a/README.md
+++ b/README.md
@@ -1,48 +1,46 @@
-Terraform Provider
-==================
+# Equinix Metal Terraform Provider
 
-- Website: https://www.terraform.io
-- [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
-- ![](https://img.shields.io/badge/Stability-Maintained-green.svg)
-- Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
+[![GitHub release](https://img.shields.io/github/release/packethost/terraform-provider-packet/all.svg?style=flat-square)](https://github.com/packethost/terraform-provider-packet/releases)
+![](https://img.shields.io/badge/Stability-Maintained-green.svg)
+[![Go Report Card](https://goreportcard.com/badge/github.com/packethost/terraform-provider-packet)](https://goreportcard.com/report/github.com/packethost/terraform-provider-packet)
 
-<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
+[![Slack](https://slack.equinixmetal.com/badge.svg)](https://slack.equinixmetal.com)
+[![Twitter Follow](https://img.shields.io/twitter/follow/equinixmetal.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=equinixmetal)
 
-This repository is [Maintained](https://github.com/packethost/standards/blob/master/maintained-statement.md) meaning that this software is supported by Packet and its community - available to use in production environments.
+<img src="https://metal.equinix.com/metal/images/logo/equinix-metal-full.svg" width="600px">
 
-Requirements
-------------
+[Packet is now Equinix Metal!](https://blog.equinix.com/blog/2020/10/06/equinix-metal-metal-and-more/)
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.13 (to build the provider plugin)
+This repository is [Maintained](https://github.com/packethost/standards/blob/master/maintained-statement.md) meaning that this software is supported by Equinix Metal and its community - available to use in production environments.
 
-Building the provider
----------------------
+## Using the provider
+
+The Equinix Metal provider will be installed on `terraform init` of a template using any of the `packet_*` resources.
+
+See <https://registry.terraform.io/providers/packethost/packet/latest/docs> for documentation on the resources included in this provider.
+
+## Requirements
+
+- [Terraform 0.12+](https://www.terraform.io/downloads.html) (for v3.0.0 of this provider and newer)
+- [Go](https://golang.org/doc/install) 1.13 (to build the provider plugin)
+
+## Building the provider
 
 Clone repository to: `$GOPATH/src/github.com/packethost/terraform-provider-packet`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/packethost; cd $GOPATH/src/github.com/packethost
-$ git clone git@github.com:packethost/terraform-provider-packet
+mkdir -p $GOPATH/src/github.com/packethost; cd $GOPATH/src/github.com/packethost
+git clone git@github.com:packethost/terraform-provider-packet
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/packethost/terraform-provider-packet
-$ make build
+cd $GOPATH/src/github.com/packethost/terraform-provider-packet
+make build
 ```
 
-Using the provider
-----------------------
-
-The packet provider will be installed on `terraform init` of a template using any of the `packet_*` resources.
-
-Available resource and datasources are documented at [https://www.terraform.io/docs/providers/packet/index.html](https://www.terraform.io/docs/providers/packet/index.html).
-
-
-Developing the provider
----------------------------
+## Developing the provider
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.13+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
@@ -55,9 +53,7 @@ $ $GOPATH/bin/terraform-provider-packet
 ...
 ```
 
-
-Testing provider code
----------------------------
+## Testing provider code
 
 We have mostly acceptance tests in the provider. There's no point for you to run them all, but you should run the one covering the functionality which you change. The acceptance test run will cost you some money, so feel free to abstain. The acceptance test suite will be run for your PR during the review process.
 
@@ -73,13 +69,10 @@ If you want to see HTTP traffic, set `TF_LOG=DEBUG`, i.e.
 TF_LOG=DEBUG TF_ACC=1 go test -v -timeout=20m -run=TestAccPacketDevice_Basic
 ```
 
-
-
-Testing the provider with Terraform
----------------------------------------
+## Testing the provider with Terraform
 
 Once you've built the plugin binary (see [Developing the provider](#developing-the-provider) above), it can be incorporated within your Terraform environment using the `-plugin-dir` option. Subsequent runs of Terraform will then use the plugin from your development environment.
 
 ```sh
-$ terraform init -plugin-dir $GOPATH/bin
+terraform init -plugin-dir $GOPATH/bin
 ```

--- a/docs/data-sources/device.md
+++ b/docs/data-sources/device.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: packet_device"
+page_title: "Equinix Metal: packet_device"
 subcategory: ""
 description: |-
-  Provides a Packet device datasource. This can be used to read existing devices.
+  Provides an Equinix Metal device datasource. This can be used to read existing devices.
 ---
 
 # packet_device
 
-Provides a Packet device datasource.
+Provides an Equinix Metal device datasource.
 
 ~> **Note:** All arguments including the `root_password` and `user_data` will be stored in
  the raw state as plain-text.

--- a/docs/data-sources/device_bgp_neighbors.md
+++ b/docs/data-sources/device_bgp_neighbors.md
@@ -1,17 +1,17 @@
 ---
-page_title: "Packet: packet_device_bgp_neighbors"
+page_title: "Equinix Metal: packet_device_bgp_neighbors"
 subcategory: ""
 description: |-
-  Provides a datasource for listing BGP neighbors of a Packet device
+  Provides a datasource for listing BGP neighbors of an Equinix Metal device
 ---
 
 # packet_device_bgp_neighbors
 
-Use this datasource to retrieve list of BGP neighbors of a device in the Packet host.
+Use this datasource to retrieve list of BGP neighbors of a device in the Equinix Metal host.
 
 To have any BGP neighbors listed, the device must be in [BGP-enabled project](../r/project.html) and have a [BGP session](../r/bgp_session.html) assigned.
 
-To learn more about using BGP in Packet, see the [packet_bgp_session](../r/bgp_session.html) resource documentation.
+To learn more about using BGP in Equinix Metal, see the [packet_bgp_session](../r/bgp_session.html) resource documentation.
 
 ## Example Usage
 

--- a/docs/data-sources/ip_block_ranges.md
+++ b/docs/data-sources/ip_block_ranges.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Packet: ip_block_ranges"
+page_title: "Equinix Metal: ip_block_ranges"
 subcategory: ""
 description: |-
   List IP address ranges allocated to a project
@@ -9,7 +9,7 @@ description: |-
 
 Use this datasource to get CIDR expressions for allocated IP blocks of all the types in a project, optionally filtered by facility.
 
-There are four types of IP blocks in Packet: global IPv4, public IPv4, private IPv4 and IPv6. Both global and public IPv4 are routable from the Internet. Public IPv4 block is allocated in a facility, and addresses from it can only be assigned to devices in that facility. Addresses from Global IPv4 block can be assigned to a device in any facility.
+There are four types of IP blocks in Equinix Metal: global IPv4, public IPv4, private IPv4 and IPv6. Both global and public IPv4 are routable from the Internet. Public IPv4 block is allocated in a facility, and addresses from it can only be assigned to devices in that facility. Addresses from Global IPv4 block can be assigned to a device in any facility.
 
 The datasource has 4 list attributes: `global_ipv4`, `public_ipv4`, `private_ipv4` and `ipv6`, each listing CIDR notation (`<network>/<mask>`) of respective blocks from the project.
 

--- a/docs/data-sources/operating_system.md
+++ b/docs/data-sources/operating_system.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: operating_system"
+page_title: "Equinix Metal: operating_system"
 subcategory: ""
 description: |-
-  Get a Packet operating system image
+  Get an Equinix Metal operating system image
 ---
 
 # packet\_operating\_system
 
-Use this data source to get Packet Operating System image.
+Use this data source to get Equinix Metal Operating System image.
 
 ## Example Usage
 

--- a/docs/data-sources/organization.md
+++ b/docs/data-sources/organization.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: packet_organization"
+page_title: "Equinix Metal: packet_organization"
 subcategory: ""
 description: |-
-  Provides a Packet Organization datasource. This can be used to read existing Organizations.
+  Provides an Equinix Metal Organization datasource. This can be used to read existing Organizations.
 ---
 
 # packet_organization
 
-Provides a Packet organization datasource.
+Provides an Equinix Metal organization datasource.
 
 ## Example Usage
 

--- a/docs/data-sources/precreated_ip_block.md
+++ b/docs/data-sources/precreated_ip_block.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: precreated_ip_block"
+page_title: "Equinix Metal: precreated_ip_block"
 subcategory: ""
 description: |-
-  Load automatically created IP blocks from your Packet project
+  Load automatically created IP blocks from your Equinix Metal project
 ---
 
 # packet\_precreated\_ip\_block
 
-Use this data source to get CIDR expression for precreated IPv6 and IPv4 blocks in Packet.
+Use this data source to get CIDR expression for precreated IPv6 and IPv4 blocks in Equinix Metal.
 You can then use the cidrsubnet TF builtin function to derive subnets.
 
 ## Example Usage

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -1,8 +1,8 @@
 ---
-page_title: "Packet: packet_project"
+page_title: "Equinix Metal: packet_project"
 subcategory: ""
 description: |-
-  Provides a Packet Project datasource.
+  Provides an Equinix Metal Project datasource.
 ---
 
 # packet\_project
@@ -38,13 +38,13 @@ The following attributes are exported:
 * `backend_transfer` - Whether Backend Transfer is enabled for this project
 * `created` - The timestamp for when the project was created
 * `updated` - The timestamp for the last time the project was updated
-* `user_ids` - List of UUIDs of user accounts which beling to this project
-* `bgp_config` - Optional BGP settings. Refer to [Packet guide for BGP](https://www.packet.com/developers/docs/network/advanced/local-and-global-bgp/).
+* `user_ids` - List of UUIDs of user accounts which belong to this project
+* `bgp_config` - Optional BGP settings. Refer to [Equinix Metal guide for BGP](https://metal.equinix.com/developers/docs/networking/local-global-bgp/).
 
 The `bgp_config` block contains:
 
-* `asn` - Autonomous System Numer for local BGP deployment
+* `asn` - Autonomous System Number for local BGP deployment
 * `md5` - Password for BGP session in plaintext (not a checksum)
-* `deployment_type` - `private` or `public`, the `private` is likely to be usable immediately, the `public` will need to be review by Packet engineers
+* `deployment_type` - `private` or `public`, the `private` is likely to be usable immediately, the `public` will need to be review by Equinix Metal engineers
 * `status` - status of BGP configuration in the project
 * `max_prefix` - The maximum number of route filters allowed per server

--- a/docs/data-sources/project_ssh_key.md
+++ b/docs/data-sources/project_ssh_key.md
@@ -1,8 +1,8 @@
 ---
-page_title: "Packet: packet_project_ssh_key"
+page_title: "Equinix Metal: packet_project_ssh_key"
 subcategory: ""
 description: |-
-  Provides a Packet Project SSH Key datasource.
+  Provides an Equinix Metal Project SSH Key datasource.
 ---
 
 # packet\_project\_ssh\_key
@@ -24,9 +24,9 @@ data "packet_project_ssh_key" "my_key" {
 The following arguments are supported:
 
 * `search` - (Optional) The name, fingerprint, or public_key of the SSH Key to search for
-  in the Packet project
-* `id` - (Optional) The id of the SSH Key to search for in the Packet project
-* `project_id` - The Packet project id of the Packet SSH Key
+  in the Equinix Metal project
+* `id` - (Optional) The id of the SSH Key to search for in the Equinix Metal project
+* `project_id` - The Equinix Metal project id of the Equinix Metal SSH Key
 
 One of either `search` or `id` must be provided along with `project_id`.
 

--- a/docs/data-sources/spot_market_price.md
+++ b/docs/data-sources/spot_market_price.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: spot_market_price"
+page_title: "Equinix Metal: spot_market_price"
 subcategory: ""
 description: |-
-  Get a Packet Spot Market Price
+  Get an Equinix Metal Spot Market Price
 ---
 
 # packet\_operating\_system
 
-Use this data source to get Packet Spot Market Price.
+Use this data source to get Equinix Metal Spot Market Price.
 
 ## Example Usage
 

--- a/docs/data-sources/spot_market_request.md
+++ b/docs/data-sources/spot_market_request.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: packet_spot_market_request"
+page_title: "Equinix Metal: packet_spot_market_request"
 subcategory: ""
 description: |-
-  Provides a datasource for existing Spot Market Requests in the Packet host.
+  Provides a datasource for existing Spot Market Requests in the Equinix Metal host.
 ---
 
 # packet_spot_market_request
 
-Provides a Packet spot_market_request datasource. The datasource will contain list of device IDs created by referenced Spot Market Request.
+Provides an Equinix Metal spot_market_request datasource. The datasource will contain list of device IDs created by referenced Spot Market Request.
 
 ## Example Usage
 

--- a/docs/data-sources/volume.md
+++ b/docs/data-sources/volume.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: packet_volume"
+page_title: "Equinix Metal: packet_volume"
 subcategory: ""
 description: |-
-  Provides a Packet Block Storage Volume Datasource.
+  Provides an Equinix Metal Block Storage Volume Datasource.
 ---
 
 # packet\_volume
 
-Provides a Packet Block Storage Volume datasource to allow you to read existing volumes.
+Provides an Equinix Metal Block Storage Volume datasource to allow you to read existing volumes.
 
 ## Example Usage
 
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `volume_id` ID of volume for lookup
 * `name` - Name of volume for lookup
-* `project_id` - The ID the parent Packet project (for lookup by name)
+* `project_id` - The ID the parent Equinix Metal project (for lookup by name)
 
 Either `volume_id` or both `project_id` and `name` must be specified.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,30 +1,30 @@
 ---
 layout: ""
-page_title: "Provider: Packet"
+page_title: "Provider: Equinix Metal"
 description: |-
-  The Packet provider is used to interact with the Packet Host API.
+  The Equinix Metal provider is used to interact with the Equinix Metal Host API.
 ---
 
-# Packet Provider
+# Equinix Metal Provider
 
-The Packet provider is used to interact with the resources supported by Packet.
+[Packet is now Equinix Metal!](https://blog.equinix.com/blog/2020/10/06/equinix-metal-metal-and-more/)
+
+The Equinix Metal (`packet`) provider is used to interact with the resources supported by [Equinix Metal](https://metal.equinix.com/).
 The provider needs to be configured with the proper credentials before it can be used.
 
 Use the navigation to the left to read about the available resources.
 
-Be cautious when using the `packet_project` resource. Packet is invoicing per project, so creating many new projects will cause your Packet bill to fragment. If you want to keep your Packet bill simple, please re-use your existing projects.
-
 ## Example Usage
 
 ```hcl
-# Configure the Packet Provider.
+# Configure the Equinix Metal Provider.
 provider "packet" {
   auth_token = var.auth_token
 }
 
 # Declare your project ID
 #
-# You can find ID of your project form the URL in the Packet web app.
+# You can find ID of your project form the URL in the Equinix Metal web app.
 # For example, if you see your devices listed at
 # https://app.packet.net/projects/352000fb2-ee46-4673-93a8-de2c2bdba33b
 # .. then 352000fb2-ee46-4673-93a8-de2c2bdba33b is your project ID.
@@ -56,5 +56,5 @@ resource "packet_device" "web1" {
 
 The following arguments are supported:
 
-* `auth_token` - (Required) This is your Packet API Auth token. This can also be specified
+* `auth_token` - (Required) This is your Equinix Metal API Auth token. This can also be specified
   with the `PACKET_AUTH_TOKEN` shell environment variable.

--- a/docs/resources/bgp_session.md
+++ b/docs/resources/bgp_session.md
@@ -1,21 +1,21 @@
 ---
-page_title: "Packet: packet_bgp_session"
+page_title: "Equinix Metal: packet_bgp_session"
 subcategory: ""
 description: |-
-  BGP session in Packet Host
+  BGP session in Equinix Metal Host
 ---
 
 # packet_bgp_session
 
-Provides a resource to manage BGP sessions in Packet Host. Refer to [Packet BGP documentation](https://www.packet.com/developers/docs/network/advanced/local-and-global-bgp/) for more details.
+Provides a resource to manage BGP sessions in Equinix Metal Host. Refer to [Equinix Metal BGP documentation](https://metal.equinix.com/developers/docs/networking/local-global-bgp/) for more details.
 
 You need to have BGP config enabled in your project.
 
-BGP session must be linked to a device running [BIRD](https://bird.network.cz) or other BGP routing daemon which will control route advertisements via the session to Packet's upstream routers.
+BGP session must be linked to a device running [BIRD](https://bird.network.cz) or other BGP routing daemon which will control route advertisements via the session to Equinix Metal's upstream routers.
 
 ## Example Usage
 
-Following HCL illustrates usage of the BGP features in Packet. It will
+Following HCL illustrates usage of the BGP features in Equinix Metal. It will
 
 * spawn a device in a new BGP-enabled project
 * reserve a floating IPv4 address in the project in the same location as the device

--- a/docs/resources/connect.md
+++ b/docs/resources/connect.md
@@ -1,8 +1,8 @@
 ---
-page_title: "Packet: packet_connect"
+page_title: "Equinix Metal: packet_connect"
 subcategory: ""
 description: |-
-  Packet Connect resource was removed in version 2.7.0.
+  Equinix Metal Connect resource was removed in version 2.7.0.
 ---
 
 # packet_connect

--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: packet_device resource"
+page_title: "Equinix Metal: packet_device resource"
 subcategory: ""
 description: |-
-  Provides a Packet device resource. This can be used to create, modify, and delete devices.
+  Provides an Equinix Metal device resource. This can be used to create, modify, and delete devices.
 ---
 
 # packet_device
 
-Provides a Packet device resource. This can be used to create,
+Provides an Equinix Metal device resource. This can be used to create,
 modify, and delete devices.
 
 ~> **Note:** All arguments including the `root_password` and `user_data` will be stored in
@@ -137,24 +137,24 @@ The following arguments are supported:
 
 * `hostname` - (Required) The device name
 * `project_id` - (Required) The ID of the project in which to create the device
-* `operating_system` - (Required) The operating system slug. To find the slug, or visit [Operating Systems API docs](https://www.packet.com/developers/api/operatingsystems), set your API auth token in the top of the page and see JSON from the API response.
-* `facilities` - List of facility codes with deployment preferences. Packet API will go through the list and will deploy your device to first facility with free capacity. List items must be facility codes or `any` (a wildcard). To find the facility code, visit [Facilities API docs](https://www.packet.com/developers/api/facilities), set your API auth token in the top of the page and see JSON from the API response.
-* `plan` - (Required) The device plan slug. To find the plan slug, visit [Device plans API docs](https://www.packet.com/developers/api/plans), set your auth token in the top of the page and see JSON from the API response.
+* `operating_system` - (Required) The operating system slug. To find the slug, or visit [Operating Systems API docs](https://metal.equinix.com/developers/api/operatingsystems), set your API auth token in the top of the page and see JSON from the API response.
+* `facilities` - List of facility codes with deployment preferences. Equinix Metal API will go through the list and will deploy your device to first facility with free capacity. List items must be facility codes or `any` (a wildcard). To find the facility code, visit [Facilities API docs](https://metal.equinix.com/developers/api/facilities/), set your API auth token in the top of the page and see JSON from the API response.
+* `plan` - (Required) The device plan slug. To find the plan slug, visit [Device plans API docs](https://metal.equinix.com/developers/api/plans), set your auth token in the top of the page and see JSON from the API response.
 * `billing_cycle` - (Required) monthly or hourly
 * `user_data` (Optional) - A string of the desired User Data for the device.
 * `ipxe_script_url` (Optional) - URL pointing to a hosted iPXE script. More
   information is in the
-  [Custom iPXE](https://www.packet.com/developers/docs/servers/operating-systems/custom-ipxe/)
+  [Custom iPXE](https://metal.equinix.com/developers/docs/servers/custom-ipxe/)
   doc.
 * `always_pxe` (Optional) - If true, a device with OS `custom_ipxe` will
   continue to boot via iPXE on reboots.
 * `hardware_reservation_id` (Optional) - The `full ID` of the hardware reservation where you want this device deployed, or `next-available` if you want to pick your next available reservation automatically.
-  Please be careful when using hw reservation UUID and `next-available` together for the same pool of resevations. It might happen that the reservation which Packet API will pick as `next-available` is the reservation which you refer with UUID in another packet_device resource. If that happens, and the packet_device with the UUID is created later, resource creation will fail because the reservation is already in use (by the resource created with `next-available`). To workaround this, have the `next-available` resource  [explicitly depend_on](https://learn.hashicorp.com/terraform/getting-started/dependencies.html#implicit-and-explicit-dependencies) the resource with hw reservation UUID, so that the latter is created first. For more details, see [issue #176](https://github.com/packethost/terraform-provider-packet/issues/176).
-* `storage` (Optional) - JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](https://www.packet.com/developers/docs/servers/key-features/cpr/) doc.
+  Please be careful when using hw reservation UUID and `next-available` together for the same pool of reservations. It might happen that the reservation which Equinix Metal API will pick as `next-available` is the reservation which you refer with UUID in another packet_device resource. If that happens, and the packet_device with the UUID is created later, resource creation will fail because the reservation is already in use (by the resource created with `next-available`). To workaround this, have the `next-available` resource  [explicitly depend_on](https://learn.hashicorp.com/terraform/getting-started/dependencies.html#implicit-and-explicit-dependencies) the resource with hw reservation UUID, so that the latter is created first. For more details, see [issue #176](https://github.com/packethost/terraform-provider-packet/issues/176).
+* `storage` (Optional) - JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](https://metal.equinix.com/developers/docs/servers/custom-partitioning-raid/) doc.
   * Please note that the disks.partitions.size attribute must be a string, not an integer. It can be a number string, or size notation string, e.g. "4G" or "8M" (for gigabytes and megabytes).
 * `tags` - Tags attached to the device
 * `description` - Description string for the device
-* `project_ssh_key_ids` - Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [packet_project_ssh_key][https://www.terraform.io/docs/providers/packet/r/project_ssh_key.html] resource.
+* `project_ssh_key_ids` - Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [packet_project_ssh_key](project_ssh_key.md) resource.
 * `ip_address` (Optional) - A list of IP address types for the device (structure is documented below).
 * `wait_for_reservation_deprovision` (Optional) - Only used for devices in reserved hardware. If set, the deletion of this device will block until the hardware reservation is marked provisionable (about 4 minutes in August 2019).
 * `force_detach_volumes` (Optional) - Delete device even if it has volumes attached. Only applies for destroy action.
@@ -163,11 +163,11 @@ The `ip_address` block has 3 fields:
 
 * `type` - One of [`private_ipv4`, `public_ipv4`, `public_ipv6`]
 * `cidr` - CIDR suffix for IP address block to be assigned, i.e. amount of addresses.
-* `reservation_ids` - String of UUID of [IP block reservations](https://www.terraform.io/docs/providers/packet/r/reserved_ip_block.html) from which the public IPv4 address should be taken.
+* `reservation_ids` - String of UUID of [IP block reservations](reserved_ip_block.md) from which the public IPv4 address should be taken.
 
 You can supply one `ip_address` block per IP address type. If you use the `ip_address` you must always pass a block for `private_ipv4`.
 
-To learn more about using the reserved IP addresses for new devices, see the examples in the [packet_reserved_ip_block](https://www.terraform.io/docs/providers/packet/r/reserved_ip_block.html) documentation.
+To learn more about using the reserved IP addresses for new devices, see the examples in the [packet_reserved_ip_block](reserved_ip_block.md) documentation.
 
 ## Attributes Reference
 
@@ -195,7 +195,7 @@ The following attributes are exported:
   * `gateway` - address of router
   * `public` - whether the address is routable from the Internet
   * `family` - IP version - "4" or "6"
-* `network_type` Network type of a device, used in [Layer 2 networking](https://www.packet.com/developers/docs/network/advanced/layer-2/). Will be one of `layer3`, `hybrid`, `layer2-individual` and `layer2-bonded`.
+* `network_type` Network type of a device, used in [Layer 2 networking](https://metal.equinix.com/developers/docs/networking/layer2/). Will be one of `layer3`, `hybrid`, `layer2-individual` and `layer2-bonded`.
 * `operating_system` - The operating system running on the device
 * `plan` - The hardware config of the device
 * `ports` - Ports assigned to the device

--- a/docs/resources/device_network_type.markdown
+++ b/docs/resources/device_network_type.markdown
@@ -1,23 +1,23 @@
 ---
 layout: "packet"
-page_title: "Packet: packet_device_network_type"
+page_title: "Equinix Metal: packet_device_network_type"
 sidebar_current: "docs-packet-resource-device-network-type"
 description: |-
-  Provides a resource to manage network type of Packet devices.
+  Provides a resource to manage network type of Equinix Metal devices.
 ---
 
 # packet_device_network_type
 
-This resource controls network type of Packet devices.
+This resource controls network type of Equinix Metal devices.
 
-To learn more about Layer 2 networking in Packet, refer to
+To learn more about Layer 2 networking in Equinix Metal, refer to
 
-* <https://www.packet.com/resources/guides/layer-2-configurations/>
-* <https://www.packet.com/developers/docs/network/advanced/layer-2/>
+* <https://metal.equinix.com/developers/docs/networking/layer2/>
+* <https://metal.equinix.com/developers/docs/networking/layer2-configs/>
 
 ## Example Usage
 
-```
+```hcl
 resource "packet_device" "test" {
   hostname         = "tfacc-device-port-vlan-attachment-test"
   plan             = "s1.large.x86"
@@ -39,7 +39,7 @@ If you are attaching VLAN to a device (i.e. using packet_port_vlan_attachment), 
 
 This resource can also be imported using existing device ID:
 
-```
+```sh
 terraform import packet_device_network_type {existing device_id}
 ```
 

--- a/docs/resources/ip_attachment.md
+++ b/docs/resources/ip_attachment.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Packet: packet_ip_attachment"
+page_title: "Equinix Metal: packet_ip_attachment"
 subcategory: ""
 description: |-
   Provides a Resource for Attaching IP Subnets from a Reserved Block to a Device
@@ -14,7 +14,7 @@ one of your reserved blocks in the same project and facility as the target devic
 
 For example, you have reserved IPv4 address block 147.229.10.152/30, you can choose to assign either the whole
 block as one subnet to a device; or 2 subnets with CIDRs 147.229.10.152/31' and 147.229.10.154/31; or 4 subnets
-with mask prefix length 32. More about the elastic IP subnets is [here](https://www.packet.com/developers/docs/network/basic/elastic-ips/).
+with mask prefix length 32. More about the elastic IP subnets is [here](https://metal.equinix.com/developers/docs/networking/elastic-ips/).
 
 Device and reserved block must be in the same facility.
 

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: packet_organization"
+page_title: "Equinix Metal: packet_organization"
 subcategory: ""
 description: |-
-  Provides a Packet Organization resource.
+  Provides an Equinix Metal Organization resource.
 ---
 
 # packet\_organization
 
-Provides a resource to manage organization resource in Packet.
+Provides a resource to manage organization resource in Equinix Metal.
 
 ## Example Usage
 

--- a/docs/resources/port_vlan_attachment.md
+++ b/docs/resources/port_vlan_attachment.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Packet: packet_port_vlan_attachment"
+page_title: "Equinix Metal: packet_port_vlan_attachment"
 subcategory: ""
 description: |-
   Provides a Resource for Attaching VLANs to Device Ports
@@ -13,10 +13,10 @@ Device and VLAN must be in the same facility.
 
 If you need this resource to add the port back to bond on removal, set `force_bond = true`.
 
-To learn more about Layer 2 networking in Packet, refer to
+To learn more about Layer 2 networking in Equinix Metal, refer to
 
-* <https://www.packet.com/resources/guides/layer-2-configurations/>
-* <https://www.packet.com/developers/docs/network/advanced/layer-2/>
+* <https://metal.equinix.com/developers/docs/networking/layer2/>
+* <https://metal.equinix.com/developers/docs/networking/layer2-configs/>
 
 ## Example Usage
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -1,14 +1,16 @@
 ---
-page_title: "Packet: packet_project"
+page_title: "Equinix Metal: packet_project"
 subcategory: ""
 description: |-
-  Provides a Packet Project resource.
+  Provides an Equinix Metal Project resource.
 ---
 
 # packet\_project
 
-Provides a Packet project resource to allow you manage devices
+Provides an Equinix Metal project resource to allow you manage devices
 in your projects.
+
+-> Keep in mind that Equinix Metal invoicing is per project, so creating many `packet_project` resources will affect the rendered invoice. If you want to keep your Equinix Metal bill simple and easy to review, please re-use your existing projects.
 
 ## Example Usage
 
@@ -40,16 +42,16 @@ The following arguments are supported:
 * `name` - (Required) The name of the project
 * `organization_id` - The UUID of organization under which you want to create the project. If you leave it out, the project will be create under your the default organization of your account.
 * `payment_method_id` - The UUID of payment method for this project. The payment method and the project need to belong to the same organization (passed with `organization_id`, or default).
-* `backend_transfer` - Enable or disable [Backend Transfer](https://www.packet.com/developers/docs/network/basic/backend-transfer/), default is false
-* `bgp_config` - Optional BGP settings. Refer to [Packet guide for BGP](https://www.packet.com/developers/docs/network/advanced/local-and-global-bgp/).
+* `backend_transfer` - Enable or disable [Backend Transfer](https://metal.equinix.com/developers/docs/networking/backend-transfer/), default is false
+* `bgp_config` - Optional BGP settings. Refer to [Equinix Metal guide for BGP](https://metal.equinix.com/developers/docs/networking/local-global-bgp/).
 
-Once you set the BGP config in a project, it can't be removed (due to a limitation in the Packet API). It can be updated.
+Once you set the BGP config in a project, it can't be removed (due to a limitation in the Equinix Metal API). It can be updated.
 
 The `bgp_config` block supports:
 
 * `asn` - Autonomous System Number for local BGP deployment
 * `md5` - (Optional) Password for BGP session in plaintext (not a checksum)
-* `deployment_type` - `private` or `public`, the `private` is likely to be usable immediately, the `public` will need to be review by Packet engineers
+* `deployment_type` - `private` or `public`, the `private` is likely to be usable immediately, the `public` will need to be review by Equinix Metal engineers
 
 ## Attributes Reference
 

--- a/docs/resources/project_ssh_key.md
+++ b/docs/resources/project_ssh_key.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: packet_project_ssh_key"
+page_title: "Equinix Metal: packet_project_ssh_key"
 subcategory: ""
 description: |-
-  Provides a Packet Project SSH key resource.
+  Provides an Equinix Metal Project SSH key resource.
 ---
 
 # packet_project_ssh_key
 
-Provides a Packet project SSH key resource to manage project-specific SSH keys.
+Provides an Equinix Metal project SSH key resource to manage project-specific SSH keys.
 Project SSH keys will only be populated onto servers that belong to that project, in contrast to User SSH Keys.
 
 ## Example Usage

--- a/docs/resources/reserved_ip_block.md
+++ b/docs/resources/reserved_ip_block.md
@@ -1,15 +1,15 @@
 ---
-page_title: "Packet: packet_reserved_ip_block"
+page_title: "Equinix Metal: packet_reserved_ip_block"
 subcategory: ""
 description: |-
-  Provides a Resource for reserving IP addresses in the Packet Host
+  Provides a Resource for reserving IP addresses in the Equinix Metal Host
 ---
 
 # packet\_reserved\_ip\_block
 
 Provides a resource to create and manage blocks of reserved IP addresses in a project.
 
-When a user provisions first device in a facility, Packet API automatically allocates IPv6/56 and private IPv4/25 blocks.
+When a user provisions first device in a facility, Equinix Metal API automatically allocates IPv6/56 and private IPv4/25 blocks.
 The new device then gets IPv6 and private IPv4 addresses from those block. It also gets a public IPv4/31 address.
 Every new device in the project and facility will automatically get IPv6 and private IPv4 addresses from these pre-allocated blocks.
 The IPv6 and private IPv4 blocks can't be created, only imported. With this resource, it's possible to create either public IPv4 blocks or global IPv4 blocks.

--- a/docs/resources/spot_market_request.md
+++ b/docs/resources/spot_market_request.md
@@ -1,14 +1,14 @@
 ---
-page_title: "Packet: packet_spot_market_request"
+page_title: "Equinix Metal: packet_spot_market_request"
 subcategory: ""
 description: |-
-  Provides a Packet Spot Market Request Resource.
+  Provides an Equinix Metal Spot Market Request Resource.
 ---
 
 # packet\_spot\_market\_request
 
-Provides a Packet Spot Market Request resource to allow you to
-manage spot market requests on your account. For more detail on Spot Market, see [this article in Packet documentation](https://www.packet.com/developers/docs/getting-started/deployment-options/spot-market/).
+Provides an Equinix Metal Spot Market Request resource to allow you to
+manage spot market requests on your account. For more detail on Spot Market, see [this article in Equinix Metal documentation](https://metal.equinix.com/developers/docs/deploy/spot-market/).
 
 ## Example Usage
 

--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: packet_ssh_key"
+page_title: "Equinix Metal: packet_ssh_key"
 subcategory: ""
 description: |-
-  Provides a Packet SSH key resource.
+  Provides an Equinix Metal SSH key resource.
 ---
 
 # packet\_ssh_key
 
-Provides a resource to manage User SSH keys on your Packet user account. If you create a new device in a project, all the keys of the project's collaborators will be injected to the device.
+Provides a resource to manage User SSH keys on your Equinix Metal user account. If you create a new device in a project, all the keys of the project's collaborators will be injected to the device.
 
 The link between User SSH key and device is implicit. If you want to make sure that a key will be copied to a device, you must ensure that the device resource `depends_on` the key resource.
 
@@ -49,6 +49,6 @@ The following attributes are exported:
 * `name` - The name of the SSH key
 * `public_key` - The text of the public key
 * `fingerprint` - The fingerprint of the SSH key
-* `owner_id` - The UUID of the Packet API User who owns this key
+* `owner_id` - The UUID of the Equinix Metal API User who owns this key
 * `created` - The timestamp for when the SSH key was created
 * `updated` - The timestamp for the last time the SSH key was updated

--- a/docs/resources/vlan.md
+++ b/docs/resources/vlan.md
@@ -1,18 +1,18 @@
 ---
-page_title: "Packet: packet_vlan"
+page_title: "Equinix Metal: packet_vlan"
 subcategory: ""
 description: |-
-  Provides a resource for Packet Virtual Network.
+  Provides a resource for Equinix Metal Virtual Network.
 ---
 
 # packet_vlan
 
 Provides a resource to allow users to manage Virtual Networks in their projects.
 
-To learn more about Layer 2 networking in Packet, refer to
+To learn more about Layer 2 networking in Equinix Metal, refer to
 
-* <https://www.packet.com/resources/guides/layer-2-configurations/>
-* <https://www.packet.com/developers/docs/network/advanced/layer-2/>
+* <https://metal.equinix.com/developers/docs/networking/layer2/>
+* <https://metal.equinix.com/developers/docs/networking/layer2-configs/>
 
 ## Example Usage
 

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: packet_volume"
+page_title: "Equinix Metal: packet_volume"
 subcategory: ""
 description: |-
-  Provides a Packet Block Storage Volume Resource.
+  Provides an Equinix Metal Block Storage Volume Resource.
 ---
 
 # packet\_volume
 
-Provides a Packet Block Storage Volume resource to allow you to
+Provides an Equinix Metal Block Storage Volume resource to allow you to
 manage block volumes on your account.
 Once created by Terraform, they must then be attached and mounted
 using the api and `packet_block_attach` and `packet_block_detach`

--- a/docs/resources/volume_attachment.md
+++ b/docs/resources/volume_attachment.md
@@ -1,13 +1,13 @@
 ---
-page_title: "Packet: packet_volume_attachment"
+page_title: "Equinix Metal: packet_volume_attachment"
 subcategory: ""
 description: |-
-  Provides attachment of volumes to devices in the Packet Host.
+  Provides attachment of volumes to devices in the Equinix Metal Host.
 ---
 
 # packet\_volume\_attachment
 
-Provides attachment of Packet Block Storage Volume to Devices.
+Provides attachment of Equinix Metal Block Storage Volume to Devices.
 
 Device and volume must be in the same location (facility).
 

--- a/packet/config.go
+++ b/packet/config.go
@@ -47,7 +47,7 @@ func PacketRetryPolicy(ctx context.Context, resp *http.Response, err error) (boo
 	return false, nil
 }
 
-// Client returns a new client for accessing Packet's API.
+// Client returns a new client for accessing Equinix Metal's API.
 func (c *Config) Client() *packngo.Client {
 	httpClient := retryablehttp.NewClient()
 	httpClient.RetryWaitMin = time.Second
@@ -55,7 +55,7 @@ func (c *Config) Client() *packngo.Client {
 	httpClient.RetryMax = 10
 	httpClient.CheckRetry = PacketRetryPolicy
 	httpClient.HTTPClient.Transport = logging.NewTransport(
-		"Packet",
+		"Equinix Metal",
 		httpClient.HTTPClient.Transport)
 
 	return packngo.NewClientWithAuth(consumerToken, c.AuthToken, httpClient)

--- a/packet/datasource_packet_precreated_ip_block.go
+++ b/packet/datasource_packet_precreated_ip_block.go
@@ -60,7 +60,7 @@ func dataSourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{
 	global := d.Get("global").(bool)
 
 	if !public && global {
-		return fmt.Errorf("Private (non-public) global IP address blocks are not supported in Packet")
+		return fmt.Errorf("Private (non-public) global IP address blocks are not supported in Equinix Metal")
 	}
 
 	fval, fok := d.GetOk("facility")

--- a/packet/datasource_packet_project_ssh_key.go
+++ b/packet/datasource_packet_project_ssh_key.go
@@ -15,7 +15,7 @@ func dataSourcePacketProjectSSHKey() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"search": {
 				Type:         schema.TypeString,
-				Description:  "The name, fingerprint, id, or public_key of the SSH Key to search for in the Packet project",
+				Description:  "The name, fingerprint, id, or public_key of the SSH Key to search for in the Equinix Metal project",
 				Optional:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
@@ -28,18 +28,18 @@ func dataSourcePacketProjectSSHKey() *schema.Resource {
 			},
 			"project_id": {
 				Type:         schema.TypeString,
-				Description:  "The Packet project id of the Packet SSH Key",
+				Description:  "The Equinix Metal project id of the Equinix Metal SSH Key",
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The label of the Packet SSH Key",
+				Description: "The label of the Equinix Metal SSH Key",
 				Computed:    true,
 			},
 			"public_key": {
 				Type:        schema.TypeString,
-				Description: "The public SSH key that will be authorized for SSH access on Packet devices provisioned with this key",
+				Description: "The public SSH key that will be authorized for SSH access on Equinix Metal devices provisioned with this key",
 				Computed:    true,
 			},
 			"fingerprint": {

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -388,7 +388,7 @@ func resourcePacketDeviceCreate(d *schema.ResourceData, meta interface{}) error 
 		if isForbidden(fErr) {
 			// If the device doesn't get to the active state, we can't recover it from here.
 
-			return errors.New("provisioning time limit exceeded; the Packet team will investigate")
+			return errors.New("provisioning time limit exceeded; the Equinix Metal team will investigate")
 		}
 		return fErr
 	}

--- a/packet/resource_packet_port_vlan_attachment.go
+++ b/packet/resource_packet_port_vlan_attachment.go
@@ -113,7 +113,7 @@ func resourcePacketPortVlanAttachmentCreate(d *schema.ResourceData, meta interfa
 
 		par.VirtualNetworkID = vlanID
 
-		// Packet doesn't allow multiple VLANs to be assigned
+		// Equinix Metal doesn't allow multiple VLANs to be assigned
 		// to the same port at the same time
 		lockId := "vlan-attachment-" + port.ID
 		packetMutexKV.Lock(lockId)

--- a/packet/resource_packet_reserved_ip_block.go
+++ b/packet/resource_packet_reserved_ip_block.go
@@ -190,7 +190,7 @@ func loadBlock(d *schema.ResourceData, reservedBlock *packngo.IPAddressReservati
 	if reservedBlock.AddressFamily == 4 {
 		d.Set("quantity", ipv4CIDRToQuantity[reservedBlock.CIDR])
 	} else {
-		// In Packet, a reserved IPv6 block is allocated when a device is run in a project.
+		// In Equinix Metal, a reserved IPv6 block is allocated when a device is run in a project.
 		// It's always /56, and it can't be created with Terraform, only imported.
 		// The longest assignable prefix is /64, making it max 256 subnets per block.
 		// The following logic will hold as long as /64 is the smallest assignable subnet size.


### PR DESCRIPTION
* Rename Packet to Equinix Metal in documentation
* Updates packet.com -> metal.equinix.com URLs
* Revises social media and contact info
* Minor cleanup to README.md, index.md, and project.md
* Adds relevant badges and removes irrelevant links in README.md
* Replaces Hashicorp logo with Equinix Metal logo in README.md

Signed-off-by: Marques Johansson <mjohansson@equinix.com>