### PR TITLE
Update versions of github actions containers to address CVE-2020-15228

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2.1.2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: '1.13'
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2.3.2
+      uses: actions/checkout@v2.3.4
 
     - name: Get dependencies
       run: |
@@ -47,13 +47,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2.1.2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: '1.13'
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2.3.2
+      uses: actions/checkout@v2.3.4
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>

Fixes #285 

Let's see if the Acctest runs are free of the set-env warning.