### PR TITLE
resource_packet_spot_market_request: impl missing parameters

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,6 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/packethost/packngo v0.5.0 h1:WGpfeRMstPqgyXGUXl6b9xFsbUudXU3p0+JlYri290U=
-github.com/packethost/packngo v0.5.0/go.mod h1:aRxUEV1TprXVcWr35v8tNYgZMjv7FHaInXx224vF2fc=
 github.com/packethost/packngo v0.5.1 h1:y+jWcMnyArP3hVZRsBkAXTLhokuqdYg6JUmkshX2SMk=
 github.com/packethost/packngo v0.5.1/go.mod h1:aRxUEV1TprXVcWr35v8tNYgZMjv7FHaInXx224vF2fc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/packet/resource_packet_spot_market_request.go
+++ b/packet/resource_packet_spot_market_request.go
@@ -66,8 +66,9 @@ func resourcePacketSpotMarketRequest() *schema.Resource {
 							Computed: true,
 						},
 						"always_pxe": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"description": {
 							Type:     schema.TypeString,

--- a/packet/resource_packet_spot_market_request.go
+++ b/packet/resource_packet_spot_market_request.go
@@ -104,6 +104,11 @@ func resourcePacketSpotMarketRequest() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"tags": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 					},
 				},
 			},
@@ -206,6 +211,15 @@ func resourcePacketSpotMarketRequestCreate(d *schema.ResourceData, meta interfac
 		for _, i := range temp {
 			if i != nil {
 				params.ProjectSSHKeys = append(params.ProjectSSHKeys, i.(string))
+			}
+		}
+	}
+
+	if val, ok := d.GetOk("instance_parameters.0.tags"); ok {
+		temp := val.([]interface{})
+		for _, i := range temp {
+			if i != nil {
+				params.Tags = append(params.Tags, i.(string))
 			}
 		}
 	}


### PR DESCRIPTION
Implemented on behalf of @grahamc; mostly implemented through guesswork based on grepping through `resource_packet_device.go`. I probably missed something, ~~and this is completely untested~~.

Requires on https://github.com/packethost/packngo/pull/218.

cc @grahamc 

EDIT: Also impl `tags`. Again, probably missed something, ~~completely untested,~~ etc., etc.