### PR TITLE
fix errcheck validation warnings

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,29 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.29
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true

--- a/packet/datasource_packet_device_bgp_neighbors.go
+++ b/packet/datasource_packet_device_bgp_neighbors.go
@@ -96,9 +96,9 @@ func dataSourcePacketDeviceBGPNeighborsRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	d.Set("bgp_neighbors", getBgpNeighbors(bgpNeighborsRaw))
 	d.SetId(deviceID)
-	return nil
+	return d.Set("bgp_neighbors", getBgpNeighbors(bgpNeighborsRaw))
+
 }
 
 func getRoutesSlice(routes []packngo.BGPRoute) []map[string]interface{} {

--- a/packet/datasource_packet_ip_block_ranges.go
+++ b/packet/datasource_packet_ip_block_ranges.go
@@ -64,6 +64,11 @@ func dataSourcePacketIPBlockRangesRead(d *schema.ResourceData, meta interface{})
 
 	facility := d.Get("facility").(string)
 
+	if facility != "" {
+		facility = "-" + facility
+	}
+	d.SetId(projectID + facility + "-IPs")
+
 	publicIPv4s := []string{}
 	globalIPv4s := []string{}
 	privateIPv4s := []string{}
@@ -91,14 +96,10 @@ func dataSourcePacketIPBlockRangesRead(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	d.Set("public_ipv4", publicIPv4s)
-	d.Set("global_ipv4", globalIPv4s)
-	d.Set("private_ipv4", privateIPv4s)
-	d.Set("ipv6", theIPv6s)
-	if facility != "" {
-		facility = "-" + facility
-	}
-	d.SetId(projectID + facility + "-IPs")
-	return nil
-
+	return setMap(d, map[string]interface{}{
+		"public_ipv4":  publicIPv4s,
+		"global_ipv4":  globalIPv4s,
+		"private_ipv4": privateIPv4s,
+		"ipv6":         theIPv6s,
+	})
 }

--- a/packet/datasource_packet_operating_system.go
+++ b/packet/datasource_packet_operating_system.go
@@ -108,10 +108,12 @@ func dataSourcePacketOperatingSystemRead(d *schema.ResourceData, meta interface{
 	if len(oss) > 1 {
 		return fmt.Errorf("There is more than one operating system that matches the search criteria")
 	}
-	d.Set("name", oss[0].Name)
-	d.Set("distro", oss[0].Distro)
-	d.Set("version", oss[0].Version)
-	d.Set("slug", oss[0].Slug)
 	d.SetId(oss[0].Slug)
-	return nil
+
+	return setMap(d, map[string]interface{}{
+		"name":    oss[0].Name,
+		"distro":  oss[0].Distro,
+		"version": oss[0].Version,
+		"slug":    oss[0].Slug,
+	})
 }

--- a/packet/datasource_packet_organization.go
+++ b/packet/datasource_packet_organization.go
@@ -106,14 +106,15 @@ func dataSourcePacketOrganizationRead(d *schema.ResourceData, meta interface{}) 
 		projectIds = append(projectIds, filepath.Base(p.URL))
 	}
 
-	d.Set("organization_id", org.ID)
-	d.Set("name", org.Name)
-	d.Set("description", org.Description)
-	d.Set("website", org.Website)
-	d.Set("twitter", org.Twitter)
-	d.Set("logo", org.Logo)
-	d.Set("project_ids", projectIds)
 	d.SetId(org.ID)
 
-	return nil
+	return setMap(d, map[string]interface{}{
+		"organization_id": org.ID,
+		"name":            org.Name,
+		"description":     org.Description,
+		"website":         org.Website,
+		"twitter":         org.Twitter,
+		"logo":            org.Logo,
+		"project_ids":     projectIds,
+	})
 }

--- a/packet/datasource_packet_project.go
+++ b/packet/datasource_packet_project.go
@@ -2,7 +2,6 @@ package packet
 
 import (
 	"fmt"
-	"log"
 	"path"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -114,7 +113,6 @@ func dataSourcePacketProjectRead(d *schema.ResourceData, meta interface{}) error
 		}
 	} else {
 		projectId := projectIdRaw.(string)
-		log.Println(projectId)
 		var err error
 		project, _, err = client.Projects.Get(projectId, nil)
 		if err != nil {
@@ -122,33 +120,35 @@ func dataSourcePacketProjectRead(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	d.SetId(project.ID)
-	d.Set("payment_method_id", path.Base(project.PaymentMethod.URL))
-	d.Set("name", project.Name)
-	d.Set("project_id", project.ID)
-	d.Set("organization_id", path.Base(project.Organization.URL))
-	d.Set("created", project.Created)
-	d.Set("updated", project.Updated)
-	d.Set("backend_transfer", project.BackendTransfer)
-
-	bgpConf, _, err := client.BGPConfig.Get(project.ID, nil)
 	userIds := []string{}
 	for _, u := range project.Users {
 		userIds = append(userIds, path.Base(u.URL))
 	}
-	d.Set("user_ids", userIds)
 
-	if (err == nil) && (bgpConf != nil) {
-		// guard against an empty struct
-		if bgpConf.ID != "" {
-			err := d.Set("bgp_config", flattenBGPConfig(bgpConf))
-			if err != nil {
-				err = friendlyError(err)
-				return err
+	d.SetId(project.ID)
+
+	return setMap(d, map[string]interface{}{
+		"user_ids":          userIds,
+		"payment_method_id": path.Base(project.PaymentMethod.URL),
+		"name":              project.Name,
+		"project_id":        project.ID,
+		"organization_id":   path.Base(project.Organization.URL),
+		"created":           project.Created,
+		"updated":           project.Updated,
+		"backend_transfer":  project.BackendTransfer,
+		"bgp_config": func(d *schema.ResourceData, k string) error {
+			// bgpconfig err is expected when not defined
+			bgpConf, _, err := client.BGPConfig.Get(project.ID, nil)
+
+			if (err == nil) && (bgpConf != nil) {
+				// guard against an empty struct
+				if bgpConf.ID != "" {
+					return d.Set(k, flattenBGPConfig(bgpConf))
+				}
 			}
-		}
-	}
-	return nil
+			return nil
+		},
+	})
 }
 
 func findProjectByName(ps []packngo.Project, name string) (*packngo.Project, error) {

--- a/packet/datasource_packet_project_ssh_key.go
+++ b/packet/datasource_packet_project_ssh_key.go
@@ -110,16 +110,18 @@ func dataSourcePacketProjectSSHKeyRead(d *schema.ResourceData, meta interface{})
 	ownerID := path.Base(key.Owner.Href)
 
 	d.SetId(key.ID)
-	d.Set("name", key.Label)
-	d.Set("public_key", key.Key)
-	d.Set("fingerprint", key.FingerPrint)
-	d.Set("owner_id", ownerID)
-	d.Set("created", key.Created)
-	d.Set("updated", key.Updated)
-
-	if key.Owner.Href[:10] == "/projects/" {
-		d.Set("project_id", ownerID)
-	}
-
-	return nil
+	return setMap(d, map[string]interface{}{
+		"name":        key.Label,
+		"public_key":  key.Key,
+		"fingerprint": key.FingerPrint,
+		"owner_id":    ownerID,
+		"created":     key.Created,
+		"updated":     key.Updated,
+		"project_id": func(d *schema.ResourceData, k string) error {
+			if key.Owner.Href[:10] == "/projects/" {
+				return d.Set("project_id", ownerID)
+			}
+			return nil
+		},
+	})
 }

--- a/packet/datasource_packet_spot_market_price.go
+++ b/packet/datasource_packet_spot_market_price.go
@@ -48,7 +48,6 @@ func dataSourcePacketSpotMarketPriceRead(d *schema.ResourceData, meta interface{
 	} else {
 		return fmt.Errorf("There is no facility %s", facility)
 	}
-	d.Set("price", price)
 	d.SetId(facility)
-	return nil
+	return d.Set("price", price)
 }

--- a/packet/datasource_packet_spot_market_request.go
+++ b/packet/datasource_packet_spot_market_request.go
@@ -43,7 +43,6 @@ func dataSourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interfac
 	for i, d := range smr.Devices {
 		deviceIDs[i] = d.ID
 	}
-	d.Set("device_ids", deviceIDs)
 	d.SetId(id + strings.Join(deviceIDs, "-"))
-	return nil
+	return d.Set("device_ids", deviceIDs)
 }

--- a/packet/datasource_packet_volume.go
+++ b/packet/datasource_packet_volume.go
@@ -137,18 +137,6 @@ func dataSourcePacketVolumeRead(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	d.Set("name", volume.Name)
-	d.Set("description", volume.Description)
-	d.Set("size", volume.Size)
-	d.Set("plan", volume.Plan.Slug)
-	d.Set("facility", volume.Facility.Code)
-	d.Set("state", volume.State)
-	d.Set("billing_cycle", volume.BillingCycle)
-	d.Set("locked", volume.Locked)
-	d.Set("created", volume.Created)
-	d.Set("updated", volume.Updated)
-	d.Set("project_id", volume.Project.ID)
-
 	snapshot_policies := make([]map[string]interface{}, 0, len(volume.SnapshotPolicies))
 	for _, snapshot_policy := range volume.SnapshotPolicies {
 		policy := map[string]interface{}{
@@ -157,7 +145,6 @@ func dataSourcePacketVolumeRead(d *schema.ResourceData, meta interface{}) error 
 		}
 		snapshot_policies = append(snapshot_policies, policy)
 	}
-	d.Set("snapshot_policies", snapshot_policies)
 
 	deviceIds := []string{}
 
@@ -165,10 +152,23 @@ func dataSourcePacketVolumeRead(d *schema.ResourceData, meta interface{}) error 
 		deviceIds = append(deviceIds, path.Base(a.Device.Href))
 	}
 
-	d.Set("device_ids", deviceIds)
 	d.SetId(volume.ID)
 
-	return nil
+	return setMap(d, map[string]interface{}{
+		"name":              volume.Name,
+		"description":       volume.Description,
+		"size":              volume.Size,
+		"plan":              volume.Plan.Slug,
+		"facility":          volume.Facility.Code,
+		"state":             volume.State,
+		"billing_cycle":     volume.BillingCycle,
+		"locked":            volume.Locked,
+		"created":           volume.Created,
+		"updated":           volume.Updated,
+		"project_id":        volume.Project.ID,
+		"snapshot_policies": snapshot_policies,
+		"device_ids":        deviceIds,
+	})
 }
 
 func findVolumeByName(volumes []packngo.Volume, name string) (*packngo.Volume, error) {

--- a/packet/helpers_device.go
+++ b/packet/helpers_device.go
@@ -194,32 +194,6 @@ func waitForDeviceAttribute(d *schema.ResourceData, targets []string, pending []
 	return "", err
 }
 
-// powerOnAndWait Powers on the device and waits for it to be active.
-func powerOnAndWait(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
-	_, err := client.Devices.PowerOn(d.Id())
-	if err != nil {
-		return friendlyError(err)
-	}
-
-	_, err = waitForDeviceAttribute(d, []string{"active", "failed"}, []string{"off"}, "state", client)
-	if err != nil {
-		return err
-	}
-	state := d.Get("state").(string)
-	if state != "active" {
-		return friendlyError(fmt.Errorf("Device in non-active state \"%s\"", state))
-	}
-	return nil
-}
-
-func validateFacilityForDevice(v interface{}, k string) (ws []string, errors []error) {
-	if v.(string) == "any" {
-		errors = append(errors, fmt.Errorf(`Cannot use facility: "any"`))
-	}
-	return
-}
-
 func ipAddressSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{

--- a/packet/resource_packet_bgp_session.go
+++ b/packet/resource_packet_bgp_session.go
@@ -82,12 +82,15 @@ func resourcePacketBGPSessionRead(d *schema.ResourceData, meta interface{}) erro
 			defaultRoute = true
 		}
 	}
-	d.Set("device_id", bgpSession.Device.ID)
-	d.Set("address_family", bgpSession.AddressFamily)
-	d.Set("status", bgpSession.Status)
-	d.Set("default_route", defaultRoute)
+
 	d.SetId(bgpSession.ID)
-	return nil
+
+	return setMap(d, map[string]interface{}{
+		"device_id":      bgpSession.Device.ID,
+		"address_family": bgpSession.AddressFamily,
+		"status":         bgpSession.Status,
+		"default_route":  defaultRoute,
+	})
 }
 
 func resourcePacketBGPSessionDelete(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_device_network_type.go
+++ b/packet/resource_packet_device_network_type.go
@@ -92,8 +92,7 @@ func resourcePacketDeviceNetworkTypeRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	d.Set("type", devNType)
-	return nil
+	return d.Set("type", devNType)
 }
 
 func resourcePacketDeviceNetworkTypeUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -467,27 +467,6 @@ resource "packet_device" "test" {
 `, projSuffix, rInt, rInt, rInt)
 }
 
-func testAccCheckPacketDeviceConfig_varname_pxe(rInt int, projSuffix string) string {
-	return fmt.Sprintf(`
-resource "packet_project" "test" {
-    name = "tfacc-device-%s"
-}
-
-resource "packet_device" "test" {
-  hostname         = "tfacc-test-device-%d"
-  description      = "test-desc-%d"
-  plan             = "t1.small.x86"
-  facilities       = ["sjc1"]
-  operating_system = "ubuntu_16_04"
-  billing_cycle    = "hourly"
-  project_id       = "${packet_project.test.id}"
-  tags             = ["%d"]
-  always_pxe       = true
-  ipxe_script_url  = "http://matchbox.foo.wtf:8080/boot.ipxe"
-}
-`, projSuffix, rInt, rInt, rInt)
-}
-
 func testAccCheckPacketDeviceConfig_basic(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {

--- a/packet/resource_packet_ip_attachment.go
+++ b/packet/resource_packet_ip_attachment.go
@@ -65,28 +65,27 @@ func resourcePacketIPAttachmentRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	d.SetId(assignment.ID)
-	d.Set("address", assignment.Address)
-	d.Set("gateway", assignment.Gateway)
-	d.Set("network", assignment.Network)
-	d.Set("netmask", assignment.Netmask)
-	d.Set("address_family", assignment.AddressFamily)
-	d.Set("cidr", assignment.CIDR)
-	d.Set("public", assignment.Public)
-	d.Set("management", assignment.Management)
-	d.Set("manageable", assignment.Manageable)
-
 	g := false
 	if assignment.Global != nil {
 		g = *(assignment.Global)
 	}
-	d.Set("global", g)
 
-	d.Set("device_id", path.Base(assignment.AssignedTo.Href))
-	d.Set("cidr_notation",
-		fmt.Sprintf("%s/%d", assignment.Network, assignment.CIDR))
+	d.SetId(assignment.ID)
 
-	return nil
+	return setMap(d, map[string]interface{}{
+		"address":        assignment.Address,
+		"gateway":        assignment.Gateway,
+		"network":        assignment.Network,
+		"netmask":        assignment.Netmask,
+		"address_family": assignment.AddressFamily,
+		"cidr":           assignment.CIDR,
+		"public":         assignment.Public,
+		"management":     assignment.Management,
+		"manageable":     assignment.Manageable,
+		"global":         g,
+		"device_id":      path.Base(assignment.AssignedTo.Href),
+		"cidr_notation":  fmt.Sprintf("%s/%d", assignment.Network, assignment.CIDR),
+	})
 }
 
 func resourcePacketIPAttachmentDelete(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_organization.go
+++ b/packet/resource_packet_organization.go
@@ -109,15 +109,16 @@ func resourcePacketOrganizationRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	d.SetId(key.ID)
-	d.Set("name", key.Name)
-	d.Set("description", key.Description)
-	d.Set("website", key.Website)
-	d.Set("twitter", key.Twitter)
-	d.Set("logo", key.Logo)
-	d.Set("created", key.Created)
-	d.Set("updated", key.Updated)
 
-	return nil
+	return setMap(d, map[string]interface{}{
+		"name":        key.Name,
+		"description": key.Description,
+		"website":     key.Website,
+		"twitter":     key.Twitter,
+		"logo":        key.Logo,
+		"created":     key.Created,
+		"updated":     key.Updated,
+	})
 }
 
 func resourcePacketOrganizationUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_port_vlan_attachment.go
+++ b/packet/resource_packet_port_vlan_attachment.go
@@ -185,10 +185,12 @@ func resourcePacketPortVlanAttachmentRead(d *schema.ResourceData, meta interface
 	if !vlanFound {
 		d.SetId("")
 	}
-	d.Set("port_id", portID)
-	d.Set("vlan_id", vlanID)
-	d.Set("native", vlanNative)
-	return nil
+
+	return setMap(d, map[string]interface{}{
+		"port_id": portID,
+		"vlan_id": vlanID,
+		"native":  vlanNative,
+	})
 }
 
 func resourcePacketPortVlanAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_project.go
+++ b/packet/resource_packet_project.go
@@ -49,7 +49,7 @@ func resourcePacketProject() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return strings.ToLower(strings.Trim(old, `"`)) == strings.ToLower(strings.Trim(new, `"`))
+					return strings.EqualFold(strings.Trim(old, `"`), strings.Trim(new, `"`))
 				},
 				ValidateFunc: validation.StringMatch(uuidRE, "must be a valid UUID"),
 			},
@@ -60,7 +60,7 @@ func resourcePacketProject() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return strings.ToLower(strings.Trim(old, `"`)) == strings.ToLower(strings.Trim(new, `"`))
+					return strings.EqualFold(strings.Trim(old, `"`), strings.Trim(new, `"`))
 				},
 				ValidateFunc: validation.StringMatch(uuidRE, "must be a valid UUID"),
 			},

--- a/packet/resource_packet_project_ssh_key_test.go
+++ b/packet/resource_packet_project_ssh_key_test.go
@@ -2,7 +2,6 @@ package packet
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -44,7 +43,6 @@ func TestAccPacketProjectSSHKey_Basic(t *testing.T) {
 		t.Fatalf("Cannot generate test SSH key pair: %s", err)
 	}
 	cfg := packetProjectSSHKeyConfig_Basic(rs, publicKeyMaterial)
-	log.Printf(cfg)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/packet/resource_packet_reserved_ip_block.go
+++ b/packet/resource_packet_reserved_ip_block.go
@@ -246,8 +246,6 @@ func resourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{})
 			return nil
 		},
 	})
-
-	return nil
 }
 
 func resourcePacketReservedIPBlockDelete(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_spot_market_request.go
+++ b/packet/resource_packet_spot_market_request.go
@@ -294,9 +294,8 @@ func resourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interface{
 			facilityIDs[i] = f.ID
 		}
 	}
-	d.Set("project_id", smr.Project.ID)
 
-	return nil
+	return d.Set("project_id", smr.Project.ID)
 }
 
 func resourcePacketSpotMarketRequestDelete(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_ssh_key.go
+++ b/packet/resource_packet_ssh_key.go
@@ -100,18 +100,21 @@ func resourcePacketSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 	ownerID := path.Base(key.Owner.Href)
 
 	d.SetId(key.ID)
-	d.Set("name", key.Label)
-	d.Set("public_key", key.Key)
-	d.Set("fingerprint", key.FingerPrint)
-	d.Set("owner_id", ownerID)
-	d.Set("created", key.Created)
-	d.Set("updated", key.Updated)
 
-	if key.Owner.Href[:10] == "/projects/" {
-		d.Set("project_id", ownerID)
-	}
-
-	return nil
+	return setMap(d, map[string]interface{}{
+		"name":        key.Label,
+		"public_key":  key.Key,
+		"fingerprint": key.FingerPrint,
+		"owner_id":    ownerID,
+		"created":     key.Created,
+		"updated":     key.Updated,
+		"project_id": func(d *schema.ResourceData, k string) error {
+			if key.Owner.Href[:10] == "/projects/" {
+				return d.Set("project_id", ownerID)
+			}
+			return nil
+		},
+	})
 }
 
 func resourcePacketSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_vlan.go
+++ b/packet/resource_packet_vlan.go
@@ -67,11 +67,13 @@ func resourcePacketVlanRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 
 	}
-	d.Set("description", vlan.Description)
-	d.Set("project_id", vlan.Project.ID)
-	d.Set("vxlan", vlan.VXLAN)
-	d.Set("facility", vlan.FacilityCode)
-	return nil
+
+	return setMap(d, map[string]interface{}{
+		"description": vlan.Description,
+		"project_id":  vlan.Project.ID,
+		"vxlan":       vlan.VXLAN,
+		"facility":    vlan.FacilityCode,
+	})
 }
 
 func resourcePacketVlanDelete(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_volume.go
+++ b/packet/resource_packet_volume.go
@@ -199,18 +199,6 @@ func resourcePacketVolumeRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.Set("name", volume.Name)
-	d.Set("description", volume.Description)
-	d.Set("size", volume.Size)
-	d.Set("plan", volume.Plan.Slug)
-	d.Set("facility", volume.Facility.Code)
-	d.Set("state", volume.State)
-	d.Set("billing_cycle", volume.BillingCycle)
-	d.Set("locked", volume.Locked)
-	d.Set("created", volume.Created)
-	d.Set("updated", volume.Updated)
-	d.Set("project_id", volume.Project.ID)
-
 	snapshot_policies := make([]map[string]interface{}, 0, len(volume.SnapshotPolicies))
 	for _, snapshot_policy := range volume.SnapshotPolicies {
 		policy := map[string]interface{}{
@@ -219,15 +207,25 @@ func resourcePacketVolumeRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		snapshot_policies = append(snapshot_policies, policy)
 	}
-	d.Set("snapshot_policies", snapshot_policies)
 
-	attachments := make([]*packngo.VolumeAttachment, 0, len(volume.Attachments))
-	for _, attachment := range volume.Attachments {
-		attachments = append(attachments, attachment)
-	}
-	d.Set("attachments", attachments)
+	attachments := append([]*packngo.VolumeAttachment{}, volume.Attachments...)
 
-	return nil
+	return setMap(d, map[string]interface{}{
+		"name":              volume.Name,
+		"description":       volume.Description,
+		"size":              volume.Size,
+		"plan":              volume.Plan.Slug,
+		"facility":          volume.Facility.Code,
+		"state":             volume.State,
+		"billing_cycle":     volume.BillingCycle,
+		"locked":            volume.Locked,
+		"created":           volume.Created,
+		"updated":           volume.Updated,
+		"project_id":        volume.Project.ID,
+		"snapshot_policies": snapshot_policies,
+		"attachments":       attachments,
+	})
+
 }
 
 func resourcePacketVolumeUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_volume_attachment.go
+++ b/packet/resource_packet_volume_attachment.go
@@ -69,9 +69,10 @@ func resourcePacketVolumeAttachmentRead(d *schema.ResourceData, meta interface{}
 		}
 		return err
 	}
-	d.Set("device_id", filepath.Base(va.Device.Href))
-	d.Set("volume_id", filepath.Base(va.Volume.Href))
-	return nil
+	return setMap(d, map[string]interface{}{
+		"device_id": filepath.Base(va.Device.Href),
+		"volume_id": filepath.Base(va.Volume.Href),
+	})
 }
 
 func resourcePacketVolumeAttachmentDelete(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_volume_attachment.go
+++ b/packet/resource_packet_volume_attachment.go
@@ -40,11 +40,10 @@ func resourcePacketVolumeAttachmentCreate(d *schema.ResourceData, meta interface
 	log.Printf("[DEBUG] Attaching Volume (%s) to Instance (%s)\n", vID, dID)
 	va, _, err := client.VolumeAttachments.Create(vID, dID)
 	if err != nil {
-		switch err.(type) {
+		switch err := err.(type) {
 		case *packngo.ErrorResponse:
-			e := err.(*packngo.ErrorResponse)
-			if len(e.Errors) == 1 {
-				if e.Errors[0] == "Instance is already attached to this volume" {
+			if len(err.Errors) == 1 {
+				if err.Errors[0] == "Instance is already attached to this volume" {
 					log.Printf("[DEBUG] Volume (%s) is already attached to Instance (%s)", vID, dID)
 					break
 				}


### PR DESCRIPTION
This PR removes warnings from `make errcheck`, clears warnings `golangci-lint` would identify, enables `golangci-lint`.


Related to #275
