### PR TITLE
remove daily cron acceptance tests

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -6,8 +6,6 @@ on:
       - '**.md'
       - 'website/**'
       - 'docs/**'
-  schedule:
-    - cron: '0 13 * * *'
 jobs:
 
   build:


### PR DESCRIPTION
The daily cron is not needed for a few reasons:
* PRs are incoming daily
* The cron schedule regularly bumps into PR builds
* The sweepers stomp over active tests
* The packet provider and equinix-metal provider are on the same
schedule.

Signed-off-by: Marques Johansson <mjohansson@equinix.com>