### PR TITLE
fix BC break with hardware_reservation_id = next-available handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
+## 3.2.1 (December 10, 2020)
+
+BUG FIXES:
+- [#304](https://github.com/packethost/terraform-provider-packet/issues/304) Upon updating to 3.2.0, the breaking change would taint any devices with a stated `hardware_reservation_id = "next-available"` value and a computed UUID, before 3.2.0 this diff was ignored by the provider. The 3.1.0 diff behavior has been restored, removing the breaking change.
+
 ## 3.2.0 (December 02, 2020)
 
 BREAKING CHANGES:
-- attribute `hardware_reservation_id` of the `packet_device` resource is not intended to be read anymore. Users should read `deployed_hardware_reservation_id` to find out to which hardware reservation a device was deployed.
+- [#289](https://github.com/packethost/terraform-provider-packet/issues/289) `packet_device` attribute `hardware_reservation_id` is now for stating the intended value. The `hardware_reservation_id` of the deployed device can now be found in the computed `deployed_hardware_reservation_id` field.
 
 FEATURES:
 - [#294](https://github.com/packethost/terraform-provider-packet/pull/294) New parameters `tags` and `ipxe_script_url` for `packet_spot_market_request`

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -245,6 +245,13 @@ func resourcePacketDevice() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// backward compatibility for < 3.2.0:
+					// removing hardware_reservation_id did not force recreation
+					// (probably because of Computed:true, removed in 3.2.0)
+					if new == "" {
+						return true
+					}
+
 					dhwr, ok := d.GetOk("deployed_hardware_reservation_id")
 
 					// ignore changes to "next-available" when the state matches

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -246,6 +246,21 @@ func resourcePacketDevice() *schema.Resource {
 				ForceNew: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					dhwr, ok := d.GetOk("deployed_hardware_reservation_id")
+
+					// ignore changes to "next-available" when the state matches
+					// the deployed hardware (for "< 3.2.0" compatibility)
+					if ok && new == "next-available" && dhwr == old {
+						return true
+					}
+
+					// preseve legacy behavior to avoid BC break:
+					// ignore moves from UUID -> next-available
+					if new == "next-available" && len(old) > 0 {
+						return true
+					}
+
+					// ignore changes to hardware_reservation_id when new
+					// matches the deployed hardware
 					return ok && dhwr == new
 				},
 			},


### PR DESCRIPTION
Fixes #304 